### PR TITLE
Fixes for response headers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mermaidr
 Title: Interface to the 'MERMAID' API
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: 
     c(person(given = "Sharla",
            family = "Gelfand",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mermaidr 0.1.1
 
+* Use trailing slash on endpoints to avoid redirects.
 * Suppress warning caused by introduction of `HTTP_API_VERSION` header that is not properly handled by the `httr` package (https://github.com/r-lib/httr/issues/590).
 
 # mermaidr 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mermaidr 0.1.1
+
+* Suppress warning caused by introduction of `HTTP_API_VERSION` header that is not properly handled by the `httr` package (https://github.com/r-lib/httr/issues/590).
+
 # mermaidr 0.1.0
 
 * Initial release.

--- a/R/mermaid_get.R
+++ b/R/mermaid_get.R
@@ -93,9 +93,17 @@ get_paginated_response <- function(path, ua, token, limit) {
 }
 
 get_and_parse <- function(path, ua, token) {
-  resp <- httr::GET(path, ua, token)
+  resp <- suppress_http_warning(httr::GET(path, ua, token))
   check_errors(resp)
   jsonlite::fromJSON(httr::content(resp, "text", encoding = "UTF-8"), simplifyDataFrame = TRUE)
+}
+
+suppress_http_warning <- function(expr, warning_function = "parse_http_status", warning_regex = "NAs introduced by coercion") {
+  withCallingHandlers(expr, warning = function(w) {
+    if (length(warning_function) == 1 && length(grep(warning_function, conditionCall(w))) && length(grep(warning_regex, conditionMessage(w)))) {
+      invokeRestart("muffleWarning")
+    }
+  })
 }
 
 initial_cleanup <- function(results, endpoint) {

--- a/R/mermaid_get.R
+++ b/R/mermaid_get.R
@@ -41,9 +41,9 @@ construct_api_path <- function(endpoint, token, url, limit, ...) {
 
   if (endpoint == "projects" & is.null(token)) {
     # Need showall = TRUE if it's the "projects" endpoint and not an authenticated call
-    path <- httr::modify_url(url, path = paste0("v1/", endpoint), query = list(limit = limit, showall = TRUE, ...))
+    path <- httr::modify_url(url, path = paste0("v1/", endpoint, "/"), query = list(limit = limit, showall = TRUE, ...))
   } else {
-    path <- httr::modify_url(url, path = paste0("v1/", endpoint), query = list(limit = limit, ...))
+    path <- httr::modify_url(url, path = paste0("v1/", endpoint, "/"), query = list(limit = limit, ...))
   }
 }
 

--- a/tests/testthat/test-mermaid_GET.R
+++ b/tests/testthat/test-mermaid_GET.R
@@ -44,3 +44,17 @@ test_that("mermaid_GET returns a single endpoint in a named list", {
   expect_is(output, "list")
   expect_named(output, "sites")
 })
+
+test_that("suppress_http_warning suppresses warnings from `warning_function` with `warning_regex` only", {
+  expect_silent(suppress_http_warning(httr:::parse_single_header("HTTP_API_VERSION: v0.19.2")))
+  expect_warning(suppress_http_warning(httr:::parse_single_header("HTTP_API_VERSION: v0.19.2"), "other_function"))
+  expect_warning(suppress_http_warning(httr:::parse_single_header(c("HTTP/1.1 200 OK", "A: B", "Invalid"))), "Failed to parse headers")
+})
+
+test_that("suppress_http_warning suppresses HTTP warnings", {
+  skip_if_offline()
+  skip_on_ci()
+  skip_on_cran()
+  expect_warning(httr::GET("https://dev-api.datamermaid.org/v1/projects/"))
+  expect_silent(suppress_http_warning(httr::GET("https://dev-api.datamermaid.org/v1/projects/")))
+})


### PR DESCRIPTION
Add a trailing slash to all endpoints (before query string) to reduce presence of redirect status headers, and suppress `NA` coercion warning from `httr:::parse_http_headers()` (`HTTP_API_VERSION` response header newly introduced in the MERMAID API is not properly handled by `httr`)