### PR TITLE
mermaidr 0.4.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mermaidr
 Title: Interface to the 'MERMAID' API
-Version: 0.4.4
+Version: 0.4.5
 Authors@R: 
     c(person(given = "Sharla",
            family = "Gelfand",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mermaidr 0.4.5
+
+* Fix bug where `mermaid_get_project_data()` functions failed if `andrello` or `beyer` covariates were not present, and data for multiple projects is being selected (0.4.4 only fixed the single-project case).
+
 # mermaidr 0.4.4.
 
 * Fix bug where `mermaid_get_project_data()` functions failed if `andrello` or `beyer` covariates were not present.

--- a/R/zzz_get_project_endpoint.R
+++ b/R/zzz_get_project_endpoint.R
@@ -86,7 +86,7 @@ construct_project_endpoint_columns <- function(res, endpoint, multiple_projects 
     names(res) <- cols
     res
   } else if (multiple_projects) {
-    dplyr::select(res, tidyselect::any_of(c("project_id", "project")), mermaid_project_endpoint_columns[[endpoint]])
+    dplyr::select(res, tidyselect::any_of(c("project_id", "project")), tidyselect::any_of(mermaid_project_endpoint_columns[[endpoint]]))
   } else {
     dplyr::select(res, dplyr::any_of(mermaid_project_endpoint_columns[[endpoint]]))
   }


### PR DESCRIPTION
* Fix bug where `mermaid_get_project_data()` functions failed if `andrello` or `beyer` covariates were not present, and data for multiple projects is being selected (0.4.4 only fixed the single-project case).