### PR TITLE
mermaidr 0.6.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mermaidr
 Title: Interface to the 'MERMAID' API
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: 
     c(person(given = "Sharla",
            family = "Gelfand",
@@ -31,9 +31,9 @@ Imports:
     glue,
     stringr,
     usethis,
-    fuzzyjoin,
     readr,
-    openxlsx
+    openxlsx,
+    forcats
 RoxygenNote: 7.2.0
 Suggests: 
     testthat (>= 2.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mermaidr 0.6.1
+
+Remove fuzzyjoin/stringdist dependency, calculate differences for strings in `mermaid_import_check_options()` more manually.
+
 # mermaidr 0.6.0
 
 * Remove `mermaid_get_summary_sites()` as endpoint has been removed.

--- a/tests/testthat/test-mermaid_import_check_options.R
+++ b/tests/testthat/test-mermaid_import_check_options.R
@@ -160,3 +160,50 @@ test_that("mermaid_import_check_options returns message and table when some or a
     res
   )
 })
+
+test_that("closest_string_match is not case sensitive", {
+  res <- tibble::tibble(data_value = "TEST") %>% closest_string_match(tibble::tibble(choices = "test"))
+  expect_identical(
+    res,
+    tibble::tribble(
+      ~data_value, ~closest_choice, ~match,
+      "TEST", "test", TRUE
+    )
+  )
+})
+
+test_that("closest_string_match works", {
+  res <- tibble::tibble(data_value = c("test", "toss")) %>% closest_string_match(tibble::tibble(choices = c("test", "tess", "tests", "ross")))
+  expect_identical(
+    res,
+    tibble::tribble(
+      ~data_value, ~closest_choice, ~match,
+      "test", "test", TRUE,
+      "toss", "tess", FALSE
+    )
+  )
+})
+
+test_that("closest_string_match returns in same order passed", {
+  res <- tibble::tibble(data_value = c("toss", "test")) %>% closest_string_match(tibble::tibble(choices = c("test", "tess", "tests", "ross")))
+  expect_identical(
+    res,
+    tibble::tribble(
+      ~data_value, ~closest_choice, ~match,
+      "toss", "tess", FALSE,
+      "test", "test", TRUE
+    )
+  )
+})
+
+test_that("closest_string_match de-duplicates", {
+  res <- tibble::tibble(data_value = c("toss", "toss","test")) %>% closest_string_match(tibble::tibble(choices = c("test", "tess", "tests", "ross")))
+  expect_identical(
+    res,
+    tibble::tribble(
+      ~data_value, ~closest_choice, ~match,
+      "toss", "tess", FALSE,
+      "test", "test", TRUE
+    )
+  )
+})


### PR DESCRIPTION
# mermaidr 0.6.1

Remove fuzzyjoin/stringdist dependency, calculate differences for strings in `mermaid_import_check_options()` more manually.
