### PR TITLE
Remove _by_ in var names

### DIFF
--- a/R/mermaid_get_project_data.R
+++ b/R/mermaid_get_project_data.R
@@ -152,17 +152,17 @@ common_cols <- list(
 # For select columns and setting order
 project_data_columns <- list(
   `benthicpqts/obstransectbenthicpqts` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "quadrat_size", "num_quadrats", "num_points_per_quadrat", "observers", "quadrat_number", "benthic_category", "benthic_attribute", "growth_form", "num_points", "data_policy_benthicpqt", common_cols[["obs_closing"]]),
-  `benthicpqts/sampleunits` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "observers", "percent_cover_by_benthic_category", "data_policy_benthicpqt", common_cols[["su_closing"]]),
-  `benthicpqts/sampleevents` = c(common_cols[["se"]], "percent_cover_by_benthic_category_avg", "data_policy_benthicpqt", common_cols[["se_closing"]]),
+  `benthicpqts/sampleunits` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "observers", "percent_cover_benthic_category", "data_policy_benthicpqt", common_cols[["su_closing"]]),
+  `benthicpqts/sampleevents` = c(common_cols[["se"]], "percent_cover_benthic_category_avg", "data_policy_benthicpqt", common_cols[["se_closing"]]),
   `beltfishes/obstransectbeltfishes` = c(common_cols[["obs/su"]], "transect_length", "transect_width", "size_bin", "observers", "transect_number", "label", "fish_family", "fish_genus", "fish_taxon", "size", "biomass_constant_a", "biomass_constant_b", "biomass_constant_c", "count", "biomass_kgha", "trophic_level", "trophic_group", "functional_group", "vulnerability", "data_policy_beltfish", common_cols[["obs_closing"]]),
-  `beltfishes/sampleunits` = c(common_cols[["obs/su"]], "transect_number", "label", "size_bin", "transect_length", "transect_width", "biomass_kgha", "total_abundance", "biomass_kgha_by_trophic_group", "biomass_kgha_by_fish_family", "data_policy_beltfish", common_cols[["su_closing"]]),
-  `beltfishes/sampleevents` = c(common_cols[["se"]], "biomass_kgha_avg", "biomass_kgha_by_trophic_group_avg", "biomass_kgha_by_fish_family_avg", "data_policy_beltfish", common_cols[["se_closing"]]),
+  `beltfishes/sampleunits` = c(common_cols[["obs/su"]], "transect_number", "label", "size_bin", "transect_length", "transect_width", "biomass_kgha", "total_abundance", "biomass_kgha_trophic_group", "biomass_kgha_fish_family", "data_policy_beltfish", common_cols[["su_closing"]]),
+  `beltfishes/sampleevents` = c(common_cols[["se"]], "biomass_kgha_avg", "biomass_kgha_trophic_group_avg", "biomass_kgha_fish_family_avg", "data_policy_beltfish", common_cols[["se_closing"]]),
   `benthicpits/obstransectbenthicpits` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "interval_start", "interval_size", "label", "observers", "interval", "benthic_category", "benthic_attribute", "growth_form", "data_policy_benthicpit", common_cols[["obs_closing"]]),
-  `benthicpits/sampleunits` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "interval_start", "interval_size", "observers", "percent_cover_by_benthic_category", "data_policy_benthicpit", common_cols[["su_closing"]]),
-  `benthicpits/sampleevents` = c(common_cols[["se"]], "percent_cover_by_benthic_category_avg", "data_policy_benthicpit", common_cols[["se_closing"]]),
+  `benthicpits/sampleunits` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "interval_start", "interval_size", "observers", "percent_cover_benthic_category", "data_policy_benthicpit", common_cols[["su_closing"]]),
+  `benthicpits/sampleevents` = c(common_cols[["se"]], "percent_cover_benthic_category_avg", "data_policy_benthicpit", common_cols[["se_closing"]]),
   `benthiclits/obstransectbenthiclits` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "observers", "benthic_category", "benthic_attribute", "growth_form", "length", "total_length", "data_policy_benthiclit", common_cols[["obs_closing"]]),
-  `benthiclits/sampleunits` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "observers", "total_length", "percent_cover_by_benthic_category", "data_policy_benthiclit", common_cols[["su_closing"]]),
-  `benthiclits/sampleevents` = c(common_cols[["se"]], "percent_cover_by_benthic_category_avg", "data_policy_benthiclit", common_cols[["se_closing"]]),
+  `benthiclits/sampleunits` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "observers", "total_length", "percent_cover_benthic_category", "data_policy_benthiclit", common_cols[["su_closing"]]),
+  `benthiclits/sampleevents` = c(common_cols[["se"]], "percent_cover_benthic_category_avg", "data_policy_benthiclit", common_cols[["se_closing"]]),
   `habitatcomplexities/obshabitatcomplexities` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "interval_size", "observers", "interval", "score", "score_name", "data_policy_habitatcomplexity", common_cols[["obs_closing"]]),
   `habitatcomplexities/sampleunits` = c(common_cols[["obs/su"]], "transect_number", "transect_length", "label", "observers", "score_avg", "data_policy_habitatcomplexity", common_cols[["su_closing"]]),
   `habitatcomplexities/sampleevents` = c(common_cols[["se"]], "score_avg_avg", "data_policy_habitatcomplexity", common_cols[["se_closing"]]),
@@ -175,18 +175,17 @@ project_data_columns <- list(
 
 # For testing columns, after df-cols have been expanded
 project_data_df_columns_list <- list(
-  `beltfishes/sampleunits` = c("biomass_kgha_by_trophic_group", "biomass_kgha_by_fish_family"),
-  `beltfishes/sampleevents` = c("biomass_kgha_by_trophic_group_avg", "biomass_kgha_by_fish_family_avg"),
-  `benthicpits/sampleunits` = c("percent_cover_by_benthic_category"),
-  `benthicpits/sampleevents` = c("percent_cover_by_benthic_category_avg"),
-  `benthiclits/sampleunits` = c("percent_cover_by_benthic_category"),
-  `benthiclits/sampleevents` = c("percent_cover_by_benthic_category_avg"),
-  `benthicpqts/sampleunits` = c("percent_cover_by_benthic_category"),
-  `benthicpqts/sampleevents` = c("percent_cover_by_benthic_category_avg")
+  `beltfishes/sampleunits` = c("biomass_kgha_trophic_group", "biomass_kgha_fish_family"),
+  `beltfishes/sampleevents` = c("biomass_kgha_trophic_group_avg", "biomass_kgha_fish_family_avg"),
+  `benthicpits/sampleunits` = c("percent_cover_benthic_category"),
+  `benthicpits/sampleevents` = c("percent_cover_benthic_category_avg"),
+  `benthiclits/sampleunits` = c("percent_cover_benthic_category"),
+  `benthiclits/sampleevents` = c("percent_cover_benthic_category_avg"),
+  `benthicpqts/sampleunits` = c("percent_cover_benthic_category"),
+  `benthicpqts/sampleevents` = c("percent_cover_benthic_category_avg")
 )
 
 project_data_df_columns_list_names <- project_data_df_columns_list %>%
-  purrr::map(stringr::str_remove_all, "_by") %>%
   purrr::map(paste0, collapse = "|")
 
 project_data_df_columns <- project_data_df_columns_list %>%

--- a/R/utils_test.R
+++ b/R/utils_test.R
@@ -153,6 +153,7 @@ calculate_sus_biomass_avg_long <- function(sus, aggregate_cols = c("trophic_grou
 aggregate_ses_biomass_avg_long <- function(ses, aggregate_cols = c("trophic_group", "fish_family")) {
   aggregate_by_col <- function(col) {
     ses %>%
+      dplyr::select(-tidyselect::all_of("sample_event_id")) %>%
       dplyr::rename(sample_event_id = "id") %>%
       dplyr::select(tidyselect::all_of("sample_event_id"), dplyr::starts_with(col), tidyselect::all_of(c("depth_avg", "biomass_kgha_avg"))) %>%
       tidyr::pivot_longer(-"sample_event_id", values_to = "se") %>%
@@ -283,6 +284,7 @@ calculate_sus_score_avg_long <- function(sus) {
 
 unpack_ses_score_avg_long <- function(ses, sus_agg) {
   ses %>%
+    dplyr::select(-tidyselect::all_of("sample_event_id")) %>%
     dplyr::rename(sample_event_id = "id") %>%
     dplyr::select(dplyr::all_of(c("sample_event_id", sus_agg[["name"]]))) %>%
     tidyr::pivot_longer(-"sample_event_id", values_to = "se") %>%
@@ -355,6 +357,7 @@ calculate_sus_bleaching_long <- function(sus) {
 
 unpack_sus_bleaching_avg_long <- function(ses, sus_agg) {
   ses %>%
+    dplyr::select(-dplyr::all_of(c("sample_event_id"))) %>%
     dplyr::rename(sample_event_id = "id") %>%
     dplyr::select(dplyr::all_of(c("sample_event_id", sus_agg[["name"]]))) %>%
     tidyr::pivot_longer(-"sample_event_id", values_to = "se") %>%

--- a/R/utils_test.R
+++ b/R/utils_test.R
@@ -181,11 +181,11 @@ calculate_lit_obs_percent_cover_long <- function(obs) {
   obs_agg <- obs %>%
     dplyr::group_by(.data$fake_sample_unit_id, .data$benthic_category, .data$total_length) %>%
     dplyr::summarise(length_sum = sum(.data$length, na.rm = TRUE), .groups = "drop") %>%
-    dplyr::mutate(percent_cover_by_benthic_category = round(.data$length_sum * 100 / .data$total_length, 2)) %>%
+    dplyr::mutate(percent_cover_benthic_category = round(.data$length_sum * 100 / .data$total_length, 2)) %>%
     dplyr::select(-tidyselect::all_of(c("total_length", "length_sum"))) %>%
     tidyr::pivot_wider(
       names_from = "benthic_category",
-      values_from = "percent_cover_by_benthic_category"
+      values_from = "percent_cover_benthic_category"
     )
 
   obs_agg %>%
@@ -238,10 +238,10 @@ calculate_pit_obs_percent_cover_long <- function(obs) {
       interval_size_sum = sum(.data$interval_size, na.rm = TRUE),
       .groups = "drop"
     ) %>%
-    dplyr::mutate(percent_cover_by_benthic_category = round(.data$interval_size_sum * 100 / .data$transect_length, 2)
+    dplyr::mutate(percent_cover_benthic_category = round(.data$interval_size_sum * 100 / .data$transect_length, 2)
     ) %>%
     dplyr::select(-tidyselect::all_of(c("interval_size_sum", "transect_length"))) %>%
-    tidyr::pivot_wider(names_from = "benthic_category", values_from = "percent_cover_by_benthic_category") %>%
+    tidyr::pivot_wider(names_from = "benthic_category", values_from = "percent_cover_benthic_category") %>%
     tidyr::pivot_longer(-"fake_sample_unit_id", values_to = "obs") %>%
     dplyr::mutate(
       name = stringr::str_to_lower(.data$name),

--- a/R/zzz_get_project_endpoint.R
+++ b/R/zzz_get_project_endpoint.R
@@ -225,7 +225,7 @@ clean_df_cols <- function(.data) {
 
   .data %>%
     tidyr::unpack(cols = dplyr::all_of(df_cols), names_sep = "_") %>%
-    dplyr::rename_all(~ stringr::str_remove(.x, "_by") %>%
+    dplyr::rename_all(~ .x %>%
       stringr::str_replace_all(" |-", "_") %>%
       stringr::str_to_lower())
 }

--- a/tests/testthat/test-mermaid_get_project_data.R
+++ b/tests/testthat/test-mermaid_get_project_data.R
@@ -149,12 +149,12 @@ test_that("mermaid_get_project_data does not return the df-column in cases where
 
   # One project with, one without
   output <- mermaid_get_project_data(c("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", "3a9ecb7c-f908-4262-8769-1b4dbb0cf61a"), "benthicpit", "sampleunits")
-  expect_false("percent_cover_by_benthic_category" %in% names(output))
+  expect_false("percent_cover_benthic_category" %in% names(output))
 
   # Multiple without
   output <- mermaid_get_project_data(c("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", "4d23d2a1-774f-4ccf-b567-69f95e4ff572"), "benthicpit", "sampleunits")
   expect_named(output, project_data_test_columns[["benthicpits/sampleunits"]])
-  expect_false("percent_cover_by_benthic_category" %in% names(output))
+  expect_false("percent_cover_benthic_category" %in% names(output))
 })
 
 
@@ -186,7 +186,7 @@ test_that("Vanilla fishbelt sample unit aggregation is the same as manually aggr
   test_n_fake_sus(obs, sus_minus_zeros)
 
   # Aggregate observations to sample units - since this is vanilla fishbelt, there should be no combining of fields like reef type, reef zone, etc etc
-  # Just aggregate straight up to calculate biomass_kgha, biomass_kgha_by_trophic_group, and biomass_kgha_by_fish_family
+  # Just aggregate straight up to calculate biomass_kgha, biomass_kgha_trophic_group, and biomass_kgha_fish_family
 
   obs_agg_for_su_comparison <- calculate_obs_biomass_long(obs)
 
@@ -215,7 +215,7 @@ test_that("Vanilla fishbelt sample event aggregation is the same as manually agg
   test_n_fake_ses(sus, ses)
 
   # Aggregate sample units to sample events - since this is vanilla fishbelt, there should be no combining of fields like reef type, reef zone, etc etc - but will want to check these in the other fishbelts!
-  # Just aggregate straight up to calculate depth_avg, biomass_kgha_avg, biomass_kgha_by_trophic_group_avg, and biomass_kgha_by_fish_family_avg
+  # Just aggregate straight up to calculate depth_avg, biomass_kgha_avg, biomass_kgha_trophic_group_avg, and biomass_kgha_fish_family_avg
 
   sus_agg_for_se_comparison <- calculate_sus_biomass_avg_long(sus)
 
@@ -279,7 +279,7 @@ test_that("Variable widths fishbelt sample unit aggregation is the same as manua
   test_n_fake_sus(obs, sus_minus_zeros)
 
   # Aggregate observations to sample units - there should be no combining of fields like reef type, reef zone, etc etc
-  # Just aggregate straight up to calculate biomass_kgha, biomass_kgha_by_trophic_group, and biomass_kgha_by_fish_family
+  # Just aggregate straight up to calculate biomass_kgha, biomass_kgha_trophic_group, and biomass_kgha_fish_family
 
   obs_agg_for_su_comparison <- calculate_obs_biomass_long(obs)
 
@@ -307,7 +307,7 @@ test_that("Variable widths fishbelt sample event aggregation is the same as manu
   # Check first that there are the same number of fake SEs as real SEs
   test_n_fake_ses(sus, ses)
 
-  # Aggregate sample units to sample events - calculate depth_avg, biomass_kgha_avg, biomass_kgha_by_trophic_group_avg, and biomass_kgha_by_fish_family_avg, and compare to SE values
+  # Aggregate sample units to sample events - calculate depth_avg, biomass_kgha_avg, biomass_kgha_trophic_group_avg, and biomass_kgha_fish_family_avg, and compare to SE values
 
   sus_agg_for_se_comparison <- calculate_sus_biomass_avg_long(sus)
 
@@ -378,7 +378,7 @@ test_that("Big/small fish fishbelt sample unit aggregation is the same as manual
   # )
   #
   # # Aggregate observations to sample units
-  # # Calculate biomass_kgha, biomass_kgha_by_trophic_group, and biomass_kgha_by_fish_family
+  # # Calculate biomass_kgha, biomass_kgha_trophic_group, and biomass_kgha_fish_family
   # # Also concatenate labels, width, fish size bin, reef slope, visibility, current, relative depth, and tide
   #
   # obs_agg_biomass_long <- calculate_obs_biomass_long(obs) %>%
@@ -423,7 +423,7 @@ test_that("Big/small fish fishbelt sample event aggregation is the same as manua
   test_n_fake_ses(sus, ses)
 
   # Aggregate SUs to sample events
-  # Calculate biomass_kgha_avg, biomass_kgha_by_trophic_group_avg, and biomgass_kgha_by_fish_family_avg
+  # Calculate biomass_kgha_avg, biomass_kgha_trophic_group_avg, and biomgass_kgha_fish_family_avg
   sus_agg_for_se_comparison <- calculate_sus_biomass_avg_long(sus)
 
   ses_for_se_comparison <- aggregate_ses_biomass_avg_long(ses)
@@ -455,7 +455,7 @@ test_that("Fishbelt sample unit aggregation is the same as manually aggregating 
   test_n_fake_sus(obs, sus_minus_zeros)
 
   # Aggregate observations to sample units - since this is vanilla fishbelt, there should be no combining of fields like reef type, reef zone, etc etc
-  # Just aggregate straight up to calculate biomass_kgha, biomass_kgha_by_trophic_group, and biomass_kgha_by_fish_family
+  # Just aggregate straight up to calculate biomass_kgha, biomass_kgha_trophic_group, and biomass_kgha_fish_family
 
   obs_agg_for_su_comparison <- calculate_obs_biomass_long(obs)
 
@@ -482,7 +482,7 @@ test_that("Fishbelt sample unit aggregation is the same as manually aggregating 
   test_n_fake_sus(obs, sus_minus_zeros)
 
   # Aggregate observations to sample units - since this is vanilla fishbelt, there should be no combining of fields like reef type, reef zone, etc etc
-  # Just aggregate straight up to calculate biomass_kgha, biomass_kgha_by_trophic_group, and biomass_kgha_by_fish_family
+  # Just aggregate straight up to calculate biomass_kgha, biomass_kgha_trophic_group, and biomass_kgha_fish_family
 
   obs_agg_for_su_comparison <- calculate_obs_biomass_long(obs)
 
@@ -536,7 +536,7 @@ test_that("Deep/shallow fishbelt sample unit aggregation is the same as manually
   # expect_true(all(sus_depth_different_sample_unit[["match_depth_fake_ids"]]))
   #
   # # Aggregate observations to sample units
-  # # Calculate biomass_kgha, biomass_kgha_by_trophic_group, and biomass_kgha_by_fish_family
+  # # Calculate biomass_kgha, biomass_kgha_trophic_group, and biomass_kgha_fish_family
   # # Do NOT concatenate any fields
   #
   # obs_agg_for_su_comparison <- calculate_obs_biomass_long(obs)
@@ -564,7 +564,7 @@ test_that("Deep/shallow fishbelt sample event aggregation is the same as manuall
   test_n_fake_ses(sus, ses)
 
   # Aggregate observations to sample events
-  # Calculate biomass_kgha_avg, biomass_kgha_by_trophic_group_avg, and biomass_kgha_by_fish_family_avg
+  # Calculate biomass_kgha_avg, biomass_kgha_trophic_group_avg, and biomass_kgha_fish_family_avg
 
   sus_agg_for_se_comparison <- calculate_sus_biomass_avg_long(sus)
 
@@ -593,7 +593,7 @@ test_that("Benthic LIT sample unit aggregation is the same as manually aggregati
   test_n_fake_sus(obs, sus)
 
   # Aggregate observations to sample units - no combining of fields like reef type, reef zone, etc etc
-  # Just aggregate straight up to percent_cover_by_benthic_category
+  # Just aggregate straight up to percent_cover_benthic_category
 
   obs_agg_for_su_comparison <- calculate_lit_obs_percent_cover_long(obs)
 
@@ -620,7 +620,7 @@ test_that("Benthic LIT sample event aggregation is the same as manually aggregat
   test_n_fake_ses(sus, ses)
 
   # Aggregate observations to sample units - no combining of fields like reef type, reef zone, etc etc
-  # Just aggregate straight up to percent_cover_by_benthic_category_avg and depth_avg
+  # Just aggregate straight up to percent_cover_benthic_category_avg and depth_avg
 
   sus_agg_for_se_comparison <- calculate_sus_percent_cover_avg_long(sus)
 
@@ -649,7 +649,7 @@ test_that("Benthic PIT sample unit aggregation is the same as manually aggregati
   test_n_fake_sus(obs, sus)
 
   # Aggregate observations to sample units - no combining of fields like reef type, reef zone, etc etc
-  # Just aggregate straight up to percent_cover_by_benthic_category
+  # Just aggregate straight up to percent_cover_benthic_category
   # Do this by getting the length for each benthic category (sum of interval_size) divided by the total length (transect_length)
 
   obs_agg_for_su_comparison <- calculate_pit_obs_percent_cover_long(obs)
@@ -677,7 +677,7 @@ test_that("Benthic PIT sample event aggregation is the same as manually aggregat
   test_n_fake_ses(sus, ses)
 
   # Aggregate observations to sample units - no combining of fields like reef type, reef zone, etc etc
-  # Just aggregate straight up to percent_cover_by_benthic_category_avg and depth_avg
+  # Just aggregate straight up to percent_cover_benthic_category_avg and depth_avg
 
   sus_agg_for_se_comparison <- calculate_sus_percent_cover_avg_long(sus)
 
@@ -706,7 +706,7 @@ test_that("Benthic PIT sample unit aggregation is the same as manually aggregati
   test_n_fake_sus(obs, sus)
 
   # Aggregate observations to sample units - no combining of fields like reef type, reef zone, etc etc
-  # Just aggregate straight up to percent_cover_by_benthic_category
+  # Just aggregate straight up to percent_cover_benthic_category
   # Do this by getting the length for each benthic category (sum of interval_size) divided by the total length (transect_length)
 
   obs_agg_for_su_comparison <- calculate_pit_obs_percent_cover_long(obs)
@@ -1075,4 +1075,37 @@ test_that("mermaid_get_project_data with covariates = TRUE returns covars, all t
     output,
     ~ expect_true(all(covars_cols %in% names(.x)))
   )
+})
+
+# _by_ removal ----
+
+test_that("All expanded columns that formerly had _by_ in them are properly pulled down", {
+  p <- mermaid_get_my_projects()
+  cols <- project_data_df_columns_list %>%
+    purrr::map_dfr(dplyr::as_tibble, .id = "method_data") %>%
+    tidyr::separate(method_data, into = c("method", "data"), sep = "/") %>%
+    dplyr::mutate(method = dplyr::case_when(
+      method == "beltfishes" ~ "fishbelt",
+      stringr::str_starts(method, "benthic") ~ stringr::str_remove(method, "s")
+    ))
+
+  cols %>%
+    dplyr::distinct(method, data) %>%
+    dplyr::mutate(id = dplyr::row_number()) %>%
+    split(.$id) %>%
+    purrr::map(
+      function(x) {
+        res <- mermaid_get_project_data(p, x$method, x$data)
+        col <- x %>%
+          dplyr::left_join(cols, by = c("method", "data")) %>%
+          dplyr::pull(value)
+
+        purrr::walk(
+          col,
+          function(col) {
+            expect_true(any(stringr::str_starts(names(res), col)))
+          }
+        )
+      }
+    )
 })

--- a/tests/testthat/test-mermaid_get_project_data.R
+++ b/tests/testthat/test-mermaid_get_project_data.R
@@ -906,7 +906,10 @@ test_that("mermaid_get_project_data with covariates = FALSE (the default) doesn'
   skip_on_cran()
 
   p <- mermaid_get_my_projects()
-  output <- mermaid_get_project_data(p, "all", "all", limit = 1)
+  # output <- mermaid_get_project_data(p, "all", "all", limit = 1)
+
+  # TODO
+  expect_true(FALSE)
 })
 
 


### PR DESCRIPTION
`_by` is removed in variable names in API in [119](https://trello.com/c/gkFHSh7k/119-plan-for-dealing-with-nested-arbitrary-keys-bi-further-calcs-in-csv-xlsx-routes), so replacing in cols in mermaidr - doing this before tackling finishing off csv etc for 119 because new cols are needed for [adding sd](https://trello.com/c/wSHbnUsa/142-add-standard-deviations-to-agg-views)