### PR TITLE
mermaidr 1.2.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mermaidr
 Title: Interface to the 'MERMAID' API
-Version: 1.2.1
+Version: 1.2.2
 Authors@R: 
     c(person(given = "Sharla",
            family = "Gelfand",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# mermaidr 1.2.2
+
+* Add relevant life histories to `"bleaching"` method in `mermaid_get_project_data()`
+    * `data = "observations"` (`obscoloniesbleacheds` entry) gains `life_histories__competitive`, `life_histories__generalist`, `life_histories__stress_tolerant`, `life_histories__weedy`
+    * `data = "sampleunits"` gains `percent_cover_life_histories_weedy`, `percent_cover_life_histories_generalist`, `percent_cover_life_histories_competitive`, `percent_cover_life_histories_stress_tolerant`
+    * `data = "sampleevents"` gains `percent_cover_life_histories_avg_weedy`, `percent_cover_life_histories_avg_generalist`, `percent_cover_life_histories_avg_competitive`, `percent_cover_life_histories_avg_stress-tolerant`, `percent_cover_life_histories_sd_weedy`, `percent_cover_life_histories_sd_generalist`, `percent_cover_life_histories_sd_competitive`, `percent_cover_life_histories_sd_stress-tolerant`
+* Fix bug with `mermaid_get_gfcr_report()` on Windows machines
+
 # mermaidr 1.2.1
 
 * Bug fixes related to handling `mermaid_import_bulk_validate()` response

--- a/R/mermaid_get_gfcr_report.R
+++ b/R/mermaid_get_gfcr_report.R
@@ -43,7 +43,7 @@ mermaid_get_gfcr_report <- function(project, save = NULL, token = mermaid_token(
   check_errors(resp)
 
   # Check if zip -- if not, error
-  if (resp$headers$`content-type` != "application/zip") {
+  if (resp$headers$`content-encoding` != "gzip") {
     stop("Error reading GFCR report. File was not downloaded as a ZIP, as is expected.", call. = FALSE)
   }
 

--- a/R/mermaid_get_project_data.R
+++ b/R/mermaid_get_project_data.R
@@ -170,6 +170,12 @@ common_benthic_cols <- list(
   se = c(common_cols[["se"]], "percent_cover_benthic_category_avg", "percent_cover_benthic_category_sd")
 )
 
+common_bleaching_cols <- list(
+  obs = c(common_cols[["obs/su"]][!common_cols[["obs/su"]] == "reef_slope"], "quadrat_size", "label", "observers"),
+  su = c(common_cols[["obs/su"]][!common_cols[["obs/su"]] == "reef_slope"], "quadrat_size", "label", "count_total", "count_genera", "percent_normal", "percent_pale", "percent_bleached", "quadrat_count", "percent_hard_avg", "percent_hard_sd", "percent_soft_avg", "percent_soft_sd", "percent_algae_avg", "percent_algae_sd"),
+  se = c(common_cols[["se"]], "quadrat_size_avg", "count_total_avg", "count_total_sd", "count_genera_avg", "count_genera_sd", "percent_normal_avg", "percent_normal_sd", "percent_pale_avg", "percent_pale_sd", "percent_bleached_avg", "percent_bleached_sd", "quadrat_count_avg", "percent_hard_avg_avg", "percent_hard_avg_sd", "percent_soft_avg_avg", "percent_soft_avg_sd", "percent_algae_avg_avg", "percent_algae_avg_sd")
+)
+
 # For select columns and setting order
 project_data_columns <- list(
 
@@ -311,10 +317,84 @@ project_data_columns <- list(
 
   # Bleaching
 
-  `bleachingqcs/obscoloniesbleacheds` = c(common_cols[["obs/su"]][!common_cols[["obs/su"]] == "reef_slope"], "quadrat_size", "label", "observers", "benthic_attribute", "growth_form", "count_normal", "count_pale", "count_20", "count_50", "count_80", "count_100", "count_dead", "data_policy_bleachingqc", common_cols[["obs_closing"]]),
-  `bleachingqcs/obsquadratbenthicpercents` = c(common_cols[["obs/su"]][!common_cols[["obs/su"]] == "reef_slope"], "quadrat_size", "label", "observers", "quadrat_number", "percent_hard", "percent_soft", "percent_algae", "data_policy_bleachingqc", common_cols[["obs_closing"]]),
-  `bleachingqcs/sampleunits` = c(common_cols[["obs/su"]][!common_cols[["obs/su"]] == "reef_slope"], "quadrat_size", "label", "count_total", "count_genera", "percent_normal", "percent_pale", "percent_bleached", "quadrat_count", "percent_hard_avg", "percent_hard_sd", "percent_soft_avg", "percent_soft_sd", "percent_algae_avg", "percent_algae_sd", "data_policy_bleachingqc", common_cols[["su_closing"]]),
-  `bleachingqcs/sampleevents` = c(common_cols[["se"]], "quadrat_size_avg", "count_total_avg", "count_total_sd", "count_genera_avg", "count_genera_sd", "percent_normal_avg", "percent_normal_sd", "percent_pale_avg", "percent_pale_sd", "percent_bleached_avg", "percent_bleached_sd", "quadrat_count_avg", "percent_hard_avg_avg", "percent_hard_avg_sd", "percent_soft_avg_avg", "percent_soft_avg_sd", "percent_algae_avg_avg", "percent_algae_avg_sd", "data_policy_bleachingqc", common_cols[["se_closing"]])
+  `bleachingqcs/obscoloniesbleacheds` =
+    c(
+      common_bleaching_cols[["obs"]],
+      "benthic_attribute",
+      "benthic_category",
+      "growth_form",
+      "count_normal",
+      "count_pale",
+      "count_20",
+      "count_50",
+      "count_80",
+      "count_100",
+      "count_dead",
+      common_cols[["life_histories_obs"]],
+      "data_policy_bleachingqc",
+      common_cols[["obs_closing"]]
+    ),
+  `bleachingqcs/obscoloniesbleached/csv` =
+    c(
+      common_bleaching_cols[["obs"]],
+      "benthic_attribute",
+      "benthic_category",
+      "growth_form",
+      "count_normal",
+      "count_pale",
+      "count_20",
+      "count_50",
+      "count_80",
+      "count_100",
+      "count_dead",
+      common_cols[["life_histories_obs_csv"]],
+      "data_policy_bleachingqc",
+      common_cols[["obs_closing"]]
+    ),
+  `bleachingqcs/obsquadratbenthicpercents` =
+    c(
+      common_bleaching_cols[["obs"]],
+      "quadrat_number",
+      "percent_hard",
+      "percent_soft",
+      "percent_algae",
+      "data_policy_bleachingqc",
+      common_cols[["obs_closing"]]
+    ),
+  `bleachingqcs/obsquadratbenthicpercents/csv` =
+    c(
+      common_bleaching_cols[["obs"]],
+      "quadrat_number",
+      "percent_hard",
+      "percent_soft",
+      "percent_algae",
+      "data_policy_bleachingqc",
+      common_cols[["obs_closing"]]
+    ),
+  `bleachingqcs/sampleunits` = c(
+    common_bleaching_cols[["su"]],
+    common_cols[["life_histories_su"]],
+    "data_policy_bleachingqc",
+    common_cols[["su_closing"]]
+  ),
+  `bleachingqcs/sampleunits/csv` = c(
+    common_bleaching_cols[["su"]],
+    common_cols[["life_histories_su_csv"]],
+    "data_policy_bleachingqc",
+    common_cols[["su_closing"]]
+  ),
+  `bleachingqcs/sampleevents` = c(
+    common_bleaching_cols[["se"]],
+    "data_policy_bleachingqc",
+    common_cols[["life_histories_se"]],
+    common_cols[["se_closing"]]
+  ),
+  `bleachingqcs/sampleevents/csv` = c(
+    common_bleaching_cols[["se"]],
+    "data_policy_bleachingqc",
+    common_cols[["life_histories_se_csv"]],
+    common_cols[["se_closing"]]
+  )
 )
 
 project_data_columns_csv <- project_data_columns[!stringr::str_ends(names(project_data_columns), "/csv")]
@@ -331,7 +411,10 @@ project_data_columns <- append(project_data_columns[!names(project_data_columns)
 testing_cols <- list(
   benthic_obs = "life_histories",
   benthic_su = c("percent_cover_benthic_category", "percent_cover_life_histories"),
-  benthic_se = c("percent_cover_benthic_category_avg", "percent_cover_benthic_category_sd", "percent_cover_life_histories_avg", "percent_cover_life_histories_sd")
+  benthic_se = c("percent_cover_benthic_category_avg", "percent_cover_benthic_category_sd", "percent_cover_life_histories_avg", "percent_cover_life_histories_sd"),
+  bleaching_obs = "life_histories",
+  bleaching_su = c("percent_cover_life_histories"),
+  bleaching_se = c("percent_cover_life_histories_avg", "percent_cover_life_histories_sd")
 )
 
 project_data_df_columns_list <- list(
@@ -340,12 +423,15 @@ project_data_df_columns_list <- list(
   `benthicpits/obstransectbenthicpits` = testing_cols[["benthic_obs"]],
   `benthiclits/obstransectbenthiclits` = testing_cols[["benthic_obs"]],
   `benthicpqts/obstransectbenthicpqts` = testing_cols[["benthic_obs"]],
+  `bleachingqcs/obscoloniesbleacheds` = testing_cols[["bleaching_obs"]],
   `benthicpits/sampleunits` = testing_cols[["benthic_su"]],
   `benthicpits/sampleevents` = testing_cols[["benthic_se"]],
   `benthiclits/sampleunits` = testing_cols[["benthic_su"]],
   `benthiclits/sampleevents` = testing_cols[["benthic_se"]],
   `benthicpqts/sampleunits` = testing_cols[["benthic_su"]],
-  `benthicpqts/sampleevents` = testing_cols[["benthic_se"]]
+  `benthicpqts/sampleevents` = testing_cols[["benthic_se"]],
+  `bleachingqcs/sampleunits` = testing_cols[["bleaching_su"]],
+  `bleachingqcs/sampleevents` = testing_cols[["bleaching_se"]]
 )
 
 project_data_df_columns_list_csv <- project_data_df_columns_list

--- a/R/mermaid_import_project_data.R
+++ b/R/mermaid_import_project_data.R
@@ -71,7 +71,7 @@ mermaid_import_project_data <- function(data, project, method = c("fishbelt", "b
   }
 
   if (clearexisting) {
-    clearexisting_confirm <- usethis::ui_yeah("Setting `clearexisting = TRUE` will overwrite ALL existing {method} records.\nPlease only use this option if you would like to remove ALL {method} records and replace them with the ones being imported. Would you like to continue?", yes = "Yes", no = "No", shuffle = FALSE)
+    clearexisting_confirm <- usethis::ui_yeah("Setting `clearexisting = TRUE` will overwrite ALL existing {method} records in Collecting.\nPlease only use this option if you would like to remove ALL {method} records in Collecting and replace them with the ones being imported. Would you like to continue?", yes = "Yes", no = "No", shuffle = FALSE)
 
     if (clearexisting_confirm) {
       body <- append(body, list(clearexisting = "true"))

--- a/R/settings.R
+++ b/R/settings.R
@@ -1,4 +1,4 @@
-base_url <- "https://api.datamermaid.org"
+base_url <- "https://dev-api.datamermaid.org"
 mermaid_audience <- base_url
 mermaid_authorize_url <- "https://datamermaid.auth0.com/authorize"
 mermaid_access_url <- "https://datamermaid.auth0.com/oauth/token"

--- a/R/settings.R
+++ b/R/settings.R
@@ -1,4 +1,4 @@
-base_url <- "https://dev-api.datamermaid.org"
+base_url <- "https://api.datamermaid.org"
 mermaid_audience <- base_url
 mermaid_authorize_url <- "https://datamermaid.auth0.com/authorize"
 mermaid_access_url <- "https://datamermaid.auth0.com/oauth/token"

--- a/tests/testthat/test-get_project_endpoint.R
+++ b/tests/testthat/test-get_project_endpoint.R
@@ -83,10 +83,16 @@ test_that("agg endpoints - get_project_endpoint allows multiple projects and com
   ses <- get_project_endpoint(p, "habitatcomplexities/sampleevents", limit = 1)
   expect_true(all(project_data_test_columns[["habitatcomplexities/sampleevents"]] %in% names(ses)))
 
-  expect_named(get_project_endpoint(p, "bleachingqcs/obscoloniesbleacheds", limit = 1), c(mermaid_project_endpoint_columns[["bleachingqcs/obscoloniesbleacheds"]]))
+  obs <- get_project_endpoint(p, "bleachingqcs/obscoloniesbleacheds", limit = 1)
+  expect_true(all(project_data_test_columns[["bleachingqcs/obscoloniesbleacheds"]] %in% names(obs)))
+  expect_true(any(stringr::str_starts(names(obs), project_data_df_columns_list_names[["bleachingqcs/obscoloniesbleacheds"]])))
   expect_named(get_project_endpoint(p, "bleachingqcs/obsquadratbenthicpercents", limit = 1), c(mermaid_project_endpoint_columns[["bleachingqcs/obsquadratbenthicpercents"]]))
-  expect_named(get_project_endpoint(p, "bleachingqcs/sampleunits", limit = 1), c(mermaid_project_endpoint_columns[["bleachingqcs/sampleunits"]]))
-  expect_named(get_project_endpoint(p, "bleachingqcs/sampleevents", limit = 1), c(mermaid_project_endpoint_columns[["bleachingqcs/sampleevents"]]))
+  sus <- get_project_endpoint(p, "bleachingqcs/sampleunits", limit = 1)
+  expect_true(all(project_data_test_columns[["bleachingqcs/sampleunits"]] %in% names(sus)))
+  expect_true(any(stringr::str_starts(names(sus), project_data_df_columns_list_names[["bleachingqcs/sampleunits"]])))
+  ses <- get_project_endpoint(p, "bleachingqcs/sampleevents", limit = 1)
+  expect_true(all(project_data_test_columns[["bleachingqcs/sampleevents"]] %in% names(ses)))
+  expect_true(any(stringr::str_starts(names(ses), project_data_df_columns_list_names[["bleachingqcs/sampleevents"]])))
 
   p <- "2c0c9857-b11c-4b82-b7ef-e9b383d1233c"
   obs <- get_project_endpoint(p, "benthicpqts/obstransectbenthicpqts", limit = 1)

--- a/tests/testthat/test-mermaid_get_project_data.R
+++ b/tests/testthat/test-mermaid_get_project_data.R
@@ -67,7 +67,9 @@ test_that("mermaid_get_project_data with 'bleaching' method and 'observations' d
   skip_on_cran()
   output <- mermaid_get_project_data("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", "bleaching", "observations", limit = 1)
   expect_named(output, c("colonies_bleached", "percent_cover"))
-  expect_named(output[["colonies_bleached"]], project_data_test_columns[["bleachingqcs/obscoloniesbleacheds"]])
+  expect_true(all(project_data_test_columns[["bleachingqcs/obscoloniesbleacheds"]] %in% names(output[["colonies_bleached"]])))
+  # Missing benthic_category still
+  expect_true(any(stringr::str_starts(names(output[["colonies_bleached"]]), project_data_df_columns_list_names[["bleachingqcs/obscoloniesbleacheds"]])))
   expect_named(output[["percent_cover"]], project_data_test_columns[["bleachingqcs/obsquadratbenthicpercents"]])
 })
 
@@ -75,16 +77,17 @@ test_that("mermaid_get_project_data with 'bleaching' method and multiple values 
   skip_if_offline()
   skip_on_ci()
   skip_on_cran()
+
   output <- mermaid_get_project_data("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", "bleaching", "all", limit = 1)
   expect_named(output, c("observations", "sampleunits", "sampleevents"))
   expect_named(output[["observations"]], c("colonies_bleached", "percent_cover"))
-  expect_named(output[["observations"]][["colonies_bleached"]], project_data_test_columns[["bleachingqcs/obscoloniesbleacheds"]])
+  expect_true(all(project_data_test_columns[["bleachingqcs/obscoloniesbleacheds"]] %in% names(output[["observations"]][["colonies_bleached"]])))
   expect_named(output[["observations"]][["percent_cover"]], project_data_test_columns[["bleachingqcs/obsquadratbenthicpercents"]])
 
   output <- mermaid_get_project_data("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", "bleaching", c("sampleevents", "observations", "sampleunits"), limit = 1)
   expect_named(output, c("sampleevents", "observations", "sampleunits"))
   expect_named(output[["observations"]], c("colonies_bleached", "percent_cover"))
-  expect_named(output[["observations"]][["colonies_bleached"]], project_data_test_columns[["bleachingqcs/obscoloniesbleacheds"]])
+  expect_true(all(project_data_test_columns[["bleachingqcs/obscoloniesbleacheds"]] %in% names(output[["observations"]][["colonies_bleached"]])))
   expect_named(output[["observations"]][["percent_cover"]], project_data_test_columns[["bleachingqcs/obsquadratbenthicpercents"]])
 })
 
@@ -95,7 +98,7 @@ test_that("mermaid_get_project_data with multiple `methods` (including 'bleachin
   output <- mermaid_get_project_data("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", c("fishbelt", "bleaching"), "observations", limit = 1)
   expect_named(output, c("fishbelt", "bleaching"))
   expect_named(output[["bleaching"]], c("colonies_bleached", "percent_cover"))
-  expect_named(output[["bleaching"]][["colonies_bleached"]], project_data_test_columns[["bleachingqcs/obscoloniesbleacheds"]])
+  expect_true(all(project_data_test_columns[["bleachingqcs/obscoloniesbleacheds"]] %in% names(output[["bleaching"]][["colonies_bleached"]])))
   expect_named(output[["bleaching"]][["percent_cover"]], project_data_test_columns[["bleachingqcs/obsquadratbenthicpercents"]])
 
   output <- mermaid_get_project_data("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", c("bleaching", "benthiclit"), "all", limit = 1)
@@ -110,13 +113,17 @@ test_that("mermaid_get_project_data with multiple data returns a list with multi
   skip_on_cran()
   output <- mermaid_get_project_data("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", "bleaching", c("sampleunits", "sampleevents"), limit = 1)
   expect_named(output, c("sampleunits", "sampleevents"))
-  expect_named(output[["sampleunits"]], project_data_test_columns[["bleachingqcs/sampleunits"]])
-  expect_named(output[["sampleevents"]], project_data_test_columns[["bleachingqcs/sampleevents"]])
+  expect_true(all(project_data_test_columns[["bleachingqcs/sampleunits"]] %in% names(output[["sampleunits"]])))
+  expect_true(any(stringr::str_starts(names(output[["sampleunits"]]), project_data_df_columns_list_names[["bleachingqcs/sampleunits"]])))
+  expect_true(all(project_data_test_columns[["bleachingqcs/sampleevents"]] %in% names(output[["sampleevents"]])))
+  expect_true(any(stringr::str_starts(names(output[["sampleevents"]]), project_data_df_columns_list_names[["bleachingqcs/sampleevents"]])))
 
   output <- mermaid_get_project_data("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", "bleaching", c("sampleevents", "sampleunits"), limit = 1)
   expect_named(output, c("sampleevents", "sampleunits"))
-  expect_named(output[["sampleunits"]], project_data_test_columns[["bleachingqcs/sampleunits"]])
-  expect_named(output[["sampleevents"]], project_data_test_columns[["bleachingqcs/sampleevents"]])
+  expect_true(all(project_data_test_columns[["bleachingqcs/sampleunits"]] %in% names(output[["sampleunits"]])))
+  expect_true(any(stringr::str_starts(names(output[["sampleunits"]]), project_data_df_columns_list_names[["bleachingqcs/sampleunits"]])))
+  expect_true(all(project_data_test_columns[["bleachingqcs/sampleevents"]] %in% names(output[["sampleevents"]])))
+  expect_true(any(stringr::str_starts(names(output[["sampleevents"]]), project_data_df_columns_list_names[["bleachingqcs/sampleevents"]])))
 })
 
 test_that("mermaid_get_project_data with multiple methods returns a list with multiple elements in the same order that they were supplied", {
@@ -125,12 +132,12 @@ test_that("mermaid_get_project_data with multiple methods returns a list with mu
   skip_on_cran()
   output <- mermaid_get_project_data("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", c("bleaching", "benthicpit"), "sampleevents", limit = 1)
   expect_named(output, c("bleaching", "benthicpit"))
-  expect_named(output[["bleaching"]], project_data_test_columns[["bleachingqcs/sampleevents"]])
+  expect_true(all(project_data_test_columns[["bleachingqcs/sampleevents"]] %in% names(output[["bleaching"]])))
   expect_true(all(project_data_test_columns[["benthicpits/sampleevents"]] %in% names(output[["benthicpit"]])))
 
   output <- mermaid_get_project_data("2d6cee25-c0ff-4f6f-a8cd-667d3f2b914b", c("benthicpit", "bleaching"), "sampleevents", limit = 1)
   expect_named(output, c("benthicpit", "bleaching"))
-  expect_named(output[["bleaching"]], project_data_test_columns[["bleachingqcs/sampleevents"]])
+  expect_true(all(project_data_test_columns[["bleachingqcs/sampleevents"]] %in% names(output[["bleaching"]])))
   expect_true(all(project_data_test_columns[["benthicpits/sampleevents"]] %in% names(output[["benthicpit"]])))
 })
 
@@ -781,7 +788,7 @@ test_that("NULL values for percent cover in bleaching observations come through 
 
   res <- mermaid_get_project_data("2c0c9857-b11c-4b82-b7ef-e9b383d1233c", "bleaching", "observations")[["percent_cover"]]
 
-  expect_identical(res[["percent_soft"]], NA)
+  expect_true(any(is.na(res[["percent_soft"]])))
 })
 
 test_that("Bleaching sample unit aggregation is the same as manually aggregating observations", {
@@ -944,7 +951,6 @@ test_that("mermaid_get_project_data with covariates = FALSE (the default) doesn'
 })
 
 test_that("mermaid_get_project_data with covariates = TRUE returns covars, all the way down", {
-  # TODO
   skip_if_offline()
   skip_on_ci()
   skip_on_cran()
@@ -1125,7 +1131,8 @@ test_that("All expanded columns that formerly had _by_ in them are properly pull
     tidyr::separate(method_data, into = c("method", "data"), sep = "/") %>%
     dplyr::mutate(method = dplyr::case_when(
       method == "beltfishes" ~ "fishbelt",
-      stringr::str_starts(method, "benthic") ~ stringr::str_remove(method, "s")
+      stringr::str_starts(method, "benthic") ~ stringr::str_remove(method, "s"),
+      method == "bleachingqcs" ~ "bleaching"
     ))
 
   cols %>%

--- a/tests/testthat/test-mermaid_import_bulk_validate.R
+++ b/tests/testthat/test-mermaid_import_bulk_validate.R
@@ -34,7 +34,7 @@ test_that("validate_collect_records handles errors in sending the request", {
 
   expect_error(
     validate_collect_records(dplyr::tibble(x = "test"), mermaid_get_my_projects(limit = 1)[["id"]]),
-    "Internal Server Error"
+    "Bad Request"
   )
 })
 

--- a/tests/testthat/test-mermaid_import_project_data.R
+++ b/tests/testthat/test-mermaid_import_project_data.R
@@ -315,7 +315,7 @@ test_that("mermaid_import_project_data with NA in CSVs converts NAs to '' and su
   mermaid_import_project_data(temp, project_id, "fishbelt", dryrun = FALSE)
   collect_records <- mermaid_get_project_endpoint(project_id, "collectrecords") %>%
     tidyr::unpack(data, names_repair = "universal") %>%
-    dplyr::select(-id, -created_on, -updated_on) %>%
+    dplyr::select(-id...1, -created_on, -updated_on) %>%
     tidyr::unpack(sample_event, names_repair = "universal") %>%
     dplyr::filter(sample_date == "2022-06-15") %>%
     dplyr::select(fishbelt_transect) %>%


### PR DESCRIPTION
* Add relevant life histories to `"bleaching"` method in `mermaid_get_project_data()`
    * `data = "observations"` (`obscoloniesbleacheds` entry) gains `life_histories__competitive`, `life_histories__generalist`, `life_histories__stress_tolerant`, `life_histories__weedy`
    * `data = "sampleunits"` gains `percent_cover_life_histories_weedy`, `percent_cover_life_histories_generalist`, `percent_cover_life_histories_competitive`, `percent_cover_life_histories_stress_tolerant`
    * `data = "sampleevents"` gains `percent_cover_life_histories_avg_weedy`, `percent_cover_life_histories_avg_generalist`, `percent_cover_life_histories_avg_competitive`, `percent_cover_life_histories_avg_stress-tolerant`, `percent_cover_life_histories_sd_weedy`, `percent_cover_life_histories_sd_generalist`, `percent_cover_life_histories_sd_competitive`, `percent_cover_life_histories_sd_stress-tolerant`
* Fix bug with `mermaid_get_gfcr_report()` on Windows machines